### PR TITLE
Add config block for capacitive and restistive touch

### DIFF
--- a/src/extensions/calliopeMini/index.js
+++ b/src/extensions/calliopeMini/index.js
@@ -175,6 +175,12 @@ const MbitMorePinMode = {
     TOUCH: 'TOUCH'
 };
 
+
+const MbitMoreTouchType = {
+    CAPACITIVE: 'CAPACITIVE',
+    RESISTIVE: 'RESISTIVE'
+};
+
 /**
  * Enum for ID of buttons
  * @readonly
@@ -567,6 +573,7 @@ class MbitMore {
         this.config = {};
         this.config.mic = false;
         this.config.pinMode = {};
+        this.config.isResistiveTouch = false
     }
 
     /**
@@ -1244,6 +1251,7 @@ class MbitMore {
      * @return {?Promise} a Promise that resolves when the all commands was sent.
      */
     sendCommandSet(commands, util, force = false) {
+        console.log(commands)
         if (force) {
             this.microbitUpdateInterval = 500;
         }
@@ -1474,6 +1482,22 @@ class MbitMore {
         return this.config.pinMode[pinIndex] === MbitMorePinMode.TOUCH;
     }
 
+    configTouchType(touchType) {
+        console.log("configTouchType", touchType, this.config.isResistiveTouch);
+        if (!this.isConnected() || this.hardware === MbitMoreHardwareVersion.MICROBIT_V1) {
+            return Promise.resolve();
+        }
+        const isResistiveTouch = touchType === MbitMoreTouchType.RESISTIVE;
+        if (this.config.isResistiveTouch !== isResistiveTouch) {
+            this.config.isResistiveTouch = isResistiveTouch;
+            // Reset pin modes for touch pins
+            [0, 1, 2, 3].forEach(pin => {
+                this.config.pinMode[pin] = undefined;
+            });
+        }
+        return Promise.resolve();
+    }
+
     /**
      * Configurate touch mode of the pin.
      * @param {number} pinIndex - index of the pin as a button.
@@ -1501,7 +1525,7 @@ class MbitMore {
             [
                 {
                     id: (BLECommand.CMD_CONFIG << 5) | MbitMoreConfig.TOUCH,
-                    message: new Uint8Array([pinIndex, 1])
+                    message: new Uint8Array([pinIndex, 1, this.config.isResistiveTouch])
                 }
             ],
             util,
@@ -1948,6 +1972,30 @@ class MbitMoreBlocks {
                 text: 'P3',
                 value: MbitMoreButtonName.P3
             }
+        ];
+    }
+
+    /** 
+     * @return {array} - Menu items for touch type selector.
+    */
+    get TOUCH_TYPE_MENU() {
+        return [
+            {
+                text: formatMessage({
+                    id: 'calliopeMini.touchTypeMenu.resistive',
+                    default: 'Capacitive',
+                    description: 'label for capacitive touch type'
+                }),
+                value: MbitMoreTouchType.CAPACITIVE
+            },
+            {
+                text: formatMessage({
+                    id: 'calliopeMini.touchTypeMenu.capacitive',
+                    default: 'Resistive',
+                    description: 'label for resistive touch types'
+                }),
+                value: MbitMoreTouchType.RESISTIVE
+            },
         ];
     }
 
@@ -2426,6 +2474,22 @@ class MbitMoreBlocks {
                             type: ArgumentType.STRING,
                             menu: 'touchIDMenu',
                             defaultValue: MbitMoreButtonName.LOGO
+                        }
+                    }
+                },
+                {
+                    opcode: 'configTouchType',
+                    text: formatMessage({
+                        id: 'calliopeMini.configTouchType',
+                        default: 'set Touch Type to [TYPE]',
+                        description: 'set the touch type to capacitive or resistive touch'
+                    }),
+                    blockType: BlockType.COMMAND,
+                    arguments: {
+                        TYPE: {
+                            type: ArgumentType.STRING,
+                            menu: 'touchTypeMenu',
+                            defaultValue: MbitMoreTouchType.CAPACITIVE
                         }
                     }
                 },
@@ -2915,6 +2979,10 @@ class MbitMoreBlocks {
                     acceptReporters: false,
                     items: this.TOUCH_ID_MENU
                 },
+                touchTypeMenu: {
+                    acceptReporters: false,
+                    items: this.TOUCH_TYPE_MENU
+                },
                 touchEventMenu: {
                     acceptReporters: false,
                     items: this.TOUCH_EVENT_MENU
@@ -3055,6 +3123,7 @@ class MbitMoreBlocks {
      * @return {boolean|Promise<boolean>|undefined} - true if touched or promise that or undefinde if yield.
      */
     isPinTouched(args, util) {
+        // console.log('isPinTouched', this.config.isResistiveTouch)
         const buttonName = args.NAME;
         if (buttonName === MbitMoreButtonName.LOGO) {
             return this._peripheral.isTouched(buttonName);
@@ -3070,6 +3139,16 @@ class MbitMoreBlocks {
         );
         if (!configPromise) return; // This thread was yielded.
         return configPromise.then(() => this._peripheral.isTouched(buttonName));
+    }
+
+    /**
+     * Configure touch type for the pins.
+     * @param {object} args - The block's arguments.
+     * @param {string} args.TYPE - Type of touch configuration (resistive or capacitive).
+     * @return {Promise} - A promise that resolves when the configuration is complete.
+     */
+    configTouchType(args) {
+        return this._peripheral.configTouchType(args.TYPE);
     }
 
     /**

--- a/src/extensions/calliopeMini/index.js
+++ b/src/extensions/calliopeMini/index.js
@@ -2481,7 +2481,7 @@ class MbitMoreBlocks {
                     opcode: 'configTouchType',
                     text: formatMessage({
                         id: 'calliopeMini.configTouchType',
-                        default: 'set Touch Type to [TYPE]',
+                        default: 'set all pins to touch mode [TYPE]',
                         description: 'set the touch type to capacitive or resistive touch'
                     }),
                     blockType: BlockType.COMMAND,

--- a/src/extensions/calliopeMini/translations.json
+++ b/src/extensions/calliopeMini/translations.json
@@ -88,7 +88,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "Bluetooth",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "verbinden",
-        "calliopeMini.selectCommunicationRoute.cancel": "abbrechen"
+        "calliopeMini.selectCommunicationRoute.cancel": "abbrechen",
+        "calliopeMini.configTouchType": "setze alle Pins auf Berührungsmodus [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Resistiv",
+        "calliopeMini.touchTypeMenu.capacitive": "Kapazitiv"
     },
     "ja": {
         "calliopeMini.name": "Calliope mini",
@@ -178,7 +181,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "Bluetooth",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "つなぐ",
-        "calliopeMini.selectCommunicationRoute.cancel": "やめる"
+        "calliopeMini.selectCommunicationRoute.cancel": "やめる",
+        "calliopeMini.configTouchType": "すべてのピンをタッチモード [TYPE] に設定する",
+        "calliopeMini.touchTypeMenu.resistive": "抵抗式",
+        "calliopeMini.touchTypeMenu.capacitive": "静電容量式"
     },
     "ja-Hira": {
         "calliopeMini.name": "Calliope mini",
@@ -268,7 +274,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "むせん",
         "calliopeMini.selectCommunicationRoute.usb": "ゆうせん",
         "calliopeMini.selectCommunicationRoute.connect": "つなぐ",
-        "calliopeMini.selectCommunicationRoute.cancel": "やめる"
+        "calliopeMini.selectCommunicationRoute.cancel": "やめる",
+        "calliopeMini.configTouchType": "すべてのピンをタッチモード [TYPE] にせっていする",
+        "calliopeMini.touchTypeMenu.resistive": "ていこうしき",
+        "calliopeMini.touchTypeMenu.capacitive": "せいでんようしき"
     },
     "pt-br": {
         "calliopeMini.name": "Calliope mini",
@@ -281,7 +290,10 @@
         "calliopeMini.setAnalogOut": "Definir pino PWM[PIN]com[LEVEL]",
         "calliopeMini.setServo": "Definir Servo no pino [PIN]com ângulo de [ANGLE]॰",
         "calliopeMini.digitalValueMenu.Low": "desligado",
-        "calliopeMini.digitalValueMenu.High": "ligado"
+        "calliopeMini.digitalValueMenu.High": "ligado",
+        "calliopeMini.configTouchType": "Definir todos os pinos para o modo de toque [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Resistivo",
+        "calliopeMini.touchTypeMenu.capacitive": "Capacitivo"
     },
     "pt": {
         "calliopeMini.name": "Calliope mini",
@@ -294,7 +306,10 @@
         "calliopeMini.setAnalogOut": "Definir pino PWM[PIN]com[LEVEL]",
         "calliopeMini.setServo": "Definir Servo no pino [PIN]com ângulo de [ANGLE]॰",
         "calliopeMini.digitalValueMenu.Low": "desligado",
-        "calliopeMini.digitalValueMenu.High": "ligado"
+        "calliopeMini.digitalValueMenu.High": "ligado",
+        "calliopeMini.configTouchType": "Definir todos os pinos para o modo de toque [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Resistivo",
+        "calliopeMini.touchTypeMenu.capacitive": "Capacitivo"
     },
     "es": {
         "calliopeMini.name": "Calliope mini",
@@ -385,7 +400,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "Bluetooth",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "conectar",
-        "calliopeMini.selectCommunicationRoute.cancel": "cancelar"
+        "calliopeMini.selectCommunicationRoute.cancel": "cancelar",
+        "calliopeMini.configTouchType": "Configurar todos los pines al modo táctil [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Resistivo",
+        "calliopeMini.touchTypeMenu.capacitivo": "Capacitivo"
     },
     "fr": {
         "calliopeMini.name": "Calliope mini",
@@ -476,7 +494,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "Bluetooth",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "se connecter",
-        "calliopeMini.selectCommunicationRoute.cancel": "annuler"
+        "calliopeMini.selectCommunicationRoute.cancel": "annuler",
+        "calliopeMini.configTouchType": "Définir tous les broches en mode tactile [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Résistif",
+        "calliopeMini.touchTypeMenu.capacitive": "Capacitif"
     },
     "it": {
         "calliopeMini.name": "Calliope mini",
@@ -567,7 +588,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "Bluetooth",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "connetti",
-        "calliopeMini.selectCommunicationRoute.cancel": "annulla"
+        "calliopeMini.selectCommunicationRoute.cancel": "annulla",
+        "calliopeMini.configTouchType": "Imposta tutti i pin in modalità tocco [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Resistivo",
+        "calliopeMini.touchTypeMenu.capacitive": "Capacitivo"
     },
     "nl": {
         "calliopeMini.name": "Calliope mini",
@@ -658,7 +682,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "Bluetooth",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "verbinden",
-        "calliopeMini.selectCommunicationRoute.cancel": "annuleren"
+        "calliopeMini.selectCommunicationRoute.cancel": "annuleren",
+        "calliopeMini.configTouchType": "Stel alle pinnen in op aanraakmodus [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Resistief",
+        "calliopeMini.touchTypeMenu.capacitive": "Capacitief"
     },
     "dk": {
         "calliopeMini.name": "Calliope mini",
@@ -749,7 +776,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "Bluetooth",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "forbind",
-        "calliopeMini.selectCommunicationRoute.cancel": "annuller"
+        "calliopeMini.selectCommunicationRoute.cancel": "annuller",
+        "calliopeMini.configTouchType": "Indstil alle pins til berøringsmodus [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Resistiv",
+        "calliopeMini.touchTypeMenu.capacitive": "Kapacitiv"
     },
     "se": {
         "calliopeMini.name": "Calliope mini",
@@ -840,7 +870,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "Bluetooth",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "anslut",
-        "calliopeMini.selectCommunicationRoute.cancel": "avbryt"
+        "calliopeMini.selectCommunicationRoute.cancel": "avbryt",
+        "calliopeMini.configTouchType": "Ställ in alla stift till beröringsläge [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Resistiv",
+        "calliopeMini.touchTypeMenu.capacitive": "Kapacitiv"
     },
     "no": {
         "calliopeMini.name": "Calliope mini",
@@ -931,7 +964,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "Bluetooth",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "koble til",
-        "calliopeMini.selectCommunicationRoute.cancel": "avbryt"
+        "calliopeMini.selectCommunicationRoute.cancel": "avbryt",
+        "calliopeMini.configTouchType": "Sett alle pinner til berøringsmodus [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Resistiv",
+        "calliopeMini.touchTypeMenu.capacitive": "Kapasitiv"
     },
     "el": {
         "calliopeMini.name": "Calliope mini",
@@ -1022,7 +1058,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "Bluetooth",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "σύνδεση",
-        "calliopeMini.selectCommunicationRoute.cancel": "ακύρωση"
+        "calliopeMini.selectCommunicationRoute.cancel": "ακύρωση",
+        "calliopeMini.configTouchType": "Ορίστε όλες τις ακίδες σε λειτουργία αφής [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Αντιστατικό",
+        "calliopeMini.touchTypeMenu.capacitive": "Χωρητικό"
     },
     "pl": {
         "calliopeMini.name": "Calliope mini",
@@ -1113,7 +1152,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "Bluetooth",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "połącz",
-        "calliopeMini.selectCommunicationRoute.cancel": "anuluj"
+        "calliopeMini.selectCommunicationRoute.cancel": "anuluj",
+        "calliopeMini.configTouchType": "Ustaw wszystkie piny w trybie dotykowym [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Rezystancyjny",
+        "calliopeMini.touchTypeMenu.capacitive": "Pojemnościowy"
     },
     "uk": {
         "calliopeMini.name": "Calliope mini",
@@ -1204,7 +1246,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "Bluetooth",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "підключити",
-        "calliopeMini.selectCommunicationRoute.cancel": "скасувати"
+        "calliopeMini.selectCommunicationRoute.cancel": "скасувати",
+        "calliopeMini.configTouchType": "Встановіть всі контакти в режим дотику [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Резистивний",
+        "calliopeMini.touchTypeMenu.capacitive": "Ємнісний"
     },
     "ru": {
         "calliopeMini.name": "Calliope mini",
@@ -1295,7 +1340,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "Bluetooth",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "подключить",
-        "calliopeMini.selectCommunicationRoute.cancel": "отмена"
+        "calliopeMini.selectCommunicationRoute.cancel": "отмена",
+        "calliopeMini.configTouchType": "Установить все контакты в режим касания [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Резистивный",
+        "calliopeMini.touchTypeMenu.capacitive": "Емкостный"
     },
     "ar": {
         "calliopeMini.name": "Calliope mini",
@@ -1386,7 +1434,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "بلوتوث",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "اتصال",
-        "calliopeMini.selectCommunicationRoute.cancel": "إلغاء"
+        "calliopeMini.selectCommunicationRoute.cancel": "إلغاء",
+        "calliopeMini.configTouchType": "تعيين جميع المسامير إلى وضع اللمس [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "مقاوم",
+        "calliopeMini.touchTypeMenu.capacitive": "سعوي"
     },
     "he": {
         "calliopeMini.name": "Calliope mini",
@@ -1477,7 +1528,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "בלוטות'",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "התחבר",
-        "calliopeMini.selectCommunicationRoute.cancel": "ביטול"
+        "calliopeMini.selectCommunicationRoute.cancel": "ביטול",
+        "calliopeMini.configTouchType": "הגדר את כל הפינים למצב מגע [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "נגדי",
+        "calliopeMini.touchTypeMenu.capacitive": "קיבולי"
     },
     "ca": {
         "calliopeMini.name": "Calliope mini",
@@ -1568,7 +1622,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "Bluetooth",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "connecta",
-        "calliopeMini.selectCommunicationRoute.cancel": "cancel·la"
+        "calliopeMini.selectCommunicationRoute.cancel": "cancel·la",
+        "calliopeMini.configTouchType": "Configura tots els pins en mode tàctil [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Resistiu",
+        "calliopeMini.touchTypeMenu.capacitive": "Capacitiu"
     },
     "cs": {
         "calliopeMini.name": "Calliope mini",
@@ -1659,7 +1716,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "Bluetooth",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "připojit",
-        "calliopeMini.selectCommunicationRoute.cancel": "zrušit"
+        "calliopeMini.selectCommunicationRoute.cancel": "zrušit",
+        "calliopeMini.configTouchType": "Nastavit všechny piny do dotykového režimu [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Rezistivní",
+        "calliopeMini.touchTypeMenu.capacitive": "Kapacitní"
     },
     "et": {
         "calliopeMini.name": "Calliope mini",
@@ -1750,7 +1810,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "Bluetooth",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "ühenda",
-        "calliopeMini.selectCommunicationRoute.cancel": "tühista"
+        "calliopeMini.selectCommunicationRoute.cancel": "tühista",
+        "calliopeMini.configTouchType": "Määra kõik tihvtid puuterežiimi [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Takistuslik",
+        "calliopeMini.touchTypeMenu.capacitive": "Mahtuvuslik"
     },
     "lt": {
         "calliopeMini.name": "Calliope mini",
@@ -1841,7 +1904,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "Bluetooth",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "prisijungti",
-        "calliopeMini.selectCommunicationRoute.cancel": "atšaukti"
+        "calliopeMini.selectCommunicationRoute.cancel": "atšaukti",
+        "calliopeMini.configTouchType": "Nustatykite visus kaiščius į lietimo režimą [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Varžinis",
+        "calliopeMini.touchTypeMenu.capacitive": "Talpinis"
     },
     "lv": {
         "calliopeMini.name": "Calliope mini",
@@ -1932,7 +1998,10 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "Bluetooth",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "savienot",
-        "calliopeMini.selectCommunicationRoute.cancel": "atcelt"
+        "calliopeMini.selectCommunicationRoute.cancel": "atcelt",
+        "calliopeMini.configTouchType": "Iestatiet visus tapas uz pieskāriena režīmu [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Pretestības",
+        "calliopeMini.touchTypeMenu.capacitive": "Kapacitatīvs"
     },
     "fi": {
         "calliopeMini.name": "Calliope mini",
@@ -2023,6 +2092,9 @@
         "calliopeMini.selectCommunicationRoute.bluetooth": "Bluetooth",
         "calliopeMini.selectCommunicationRoute.usb": "USB",
         "calliopeMini.selectCommunicationRoute.connect": "yhdistä",
-        "calliopeMini.selectCommunicationRoute.cancel": "peruuta"
+        "calliopeMini.selectCommunicationRoute.cancel": "peruuta",
+        "calliopeMini.configTouchType": "Aseta kaikki nastat kosketustilaan [TYPE]",
+        "calliopeMini.touchTypeMenu.resistive": "Resistiivinen",
+        "calliopeMini.touchTypeMenu.capacitive": "Kapasitiivinen"
     }
 }


### PR DESCRIPTION
This pull request introduces the ability to configure touch type (capacitive or resistive) for the Calliope Mini extension. The changes include adding new enums, updating configuration methods, and adding new menu items and translations.

### New Features and Configuration:

* [`src/extensions/calliopeMini/index.js`](diffhunk://#diff-817202fc445929898d7de86adab258bb9455a468a38b88cb45270c35b8f139bfR178-R183): Added `MbitMoreTouchType` enum for capacitive and resistive touch types. Updated the `MbitMore` class to include `isResistiveTouch` in the configuration and added the `configTouchType` method to handle touch type configuration. 
* [`src/extensions/calliopeMini/index.js`](diffhunk://#diff-817202fc445929898d7de86adab258bb9455a468a38b88cb45270c35b8f139bfL1504-R1528): Updated the `sendCommandSet` method to include the touch type in the message payload.

### Block and Menu Updates:

* [`src/extensions/calliopeMini/index.js`](diffhunk://#diff-817202fc445929898d7de86adab258bb9455a468a38b88cb45270c35b8f139bfR1978-R2001): Added `TOUCH_TYPE_MENU` to provide menu items for touch type selection and added a new block `configTouchType` for setting the touch type.

### Logging and Debugging:

* [`src/extensions/calliopeMini/index.js`](diffhunk://#diff-817202fc445929898d7de86adab258bb9455a468a38b88cb45270c35b8f139bfR1254): Added console logging for debugging in `sendCommandSet`, `configTouchType`, and `isPinTouched` methods. 

### Translations:

* [`src/extensions/calliopeMini/translations.json`](diffhunk://#diff-0b83f4b61dd5abf980e4480c6bbc3e116bc4675d820c48ff7a3a81b965db2e28L91-R94): Added translations for the new touch type configuration block and menu items in multiple languages. 